### PR TITLE
turned demo mode off by default

### DIFF
--- a/src/main/resources/tomcat-eureka-config/eureka/application.properties
+++ b/src/main/resources/tomcat-eureka-config/eureka/application.properties
@@ -39,7 +39,7 @@
 ###
 eureka.webapp.url=https://localhost:${tomcat.httpsPort}/eureka-webapp
 eureka.common.ephiprohibited=true
-eureka.common.demomode=true
+eureka.common.demomode=false
 #eureka.webapp.githuboauthkey=yourkey
 #eureka.webapp.githuboauthsecret=yoursecret
 #eureka.webapp.googleoauthkey=yourkey


### PR DESCRIPTION
The demo mode was set to true in the application.properties file in tomcat-eureka-config folder. The embedded tomcat uses this file from target/eureka-config after the mvn clean install. Tested with this setting and the demo mode is turned off for mvn tomcat7:run